### PR TITLE
Add dynamic port fallback with dev-only behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,133 +1,103 @@
-# create-bkite <a href="https://npmjs.com/package/create-bkite"><img src="https://img.shields.io/npm/v/create-bkite" alt="npm package"></a>
+# 🚀 create-bkite ![npm](https://img.shields.io/npm/v/bkite)  ![npm downloads](https://img.shields.io/npm/dt/bkite)
 
-# Scaffolding Your Backend Project with **create-bkite**
+**create-bkite** is a CLI tool that helps you **instantly generate a complete backend folder structure** for your Express.js project — just like how `npm create vite@latest` does for frontend apps.
 
-**create-bkite** is a CLI tool designed to streamline the setup of **Express.js** backend projects. It scaffolds a clean and well-organized backend environment, enabling you to start coding your application immediately.
+No setup headaches. Just run one command and you're ready to code.
 
 ---
 
-## Installation and Usage
+## 🛠️ How to Use
 
-Run the following command to scaffold a new backend project:
+To scaffold your backend project, just run:
 
 ```bash
 npm create bkite@latest
 ```
 
-### Specifying Project Name
+This will ask you a few simple questions and then create a complete backend folder structure for you.
 
-You can directly specify the project name you want to use via additional command line options. For example:
+You can also:
 
-- To create a project in a folder named `my-backend-app`:  
+- Create a project in a specific folder:
   ```bash
   npm create bkite@latest my-backend-app
   ```
 
-- To scaffold a project in the current directory:  
+- Create the project in your current folder:
   ```bash
   npm create bkite@latest .
   ```
 
-Follow the interactive prompts to complete the setup.
-
 ---
 
-## Default Project Structure
+## 📁 What You Get
 
-Your new project will include the following structure:
+After running the command, you’ll get a production-ready structure like this:
 
 ```
 my-backend-app/
 ├── src/
-│   ├── configs/
-│   │   └── db.config.js
-│   ├── controllers/
-│   │   └── example.controller.js
-│   ├── middlewares/
-│   │   └── globalErrorHandler.js
-│   ├── models/
-│   ├── routes/
-│   │   └── example.routes.js
-│   ├── utils/
-│   │   ├── ApiError.js
-│   │   ├── ApiResponse.js
-│   │   └── asyncHandler.js
-│   ├── app.js
-│   └── index.js
+│   ├── configs/             # Database config
+│   ├── controllers/         # Route logic
+│   ├── middlewares/         # Error handling, etc.
+│   ├── models/              # Mongoose models (if needed)
+│   ├── routes/              # API routes
+│   ├── utils/               # Helpers like ApiError, ApiResponse
+│   ├── app.js               # Main Express app
+│   └── index.js             # Entry point
 ├── .env
 ├── .gitignore
 ├── package.json
-├── README.md
+└── README.md
 ```
 
 ---
 
-## Running Your Backend Server
+## ▶️ Run Your Server
 
-After scaffolding your project, navigate to the project directory and run the following commands:
+1. Install dependencies:
 
-1. Install dependencies:  
    ```bash
    npm install
    ```
 
-2. Start the server:  
+2. Start the server:
+
    ```bash
    npm run start
    ```
 
-By default, the server will start at **http://localhost:3000**.
+Your server will run at: **http://localhost:3000**
 
 ---
 
-## Features
+## ✨ Features
 
-- **Interactive Setup**: Guides you through project initialization with prompts.  
-- **Custom Commands**: Flexible options to scaffold in a specified folder or the current directory.  
-- **Clean Structure**: Provides a scalable and maintainable folder layout.  
-- **CORS Support**: Built-in Cross-Origin Resource Sharing (CORS) configuration.  
-- **Error Handling**: Includes a global error handler and utility classes for standardized responses.  
-- **Environment Configuration**: Prepares a `.env` file for easy environment variable management.
+- 🧠 **Simple and Interactive** — Follow prompts to set up.
+- 🗂️ **Clean Project Structure** — Easy to understand and scalable.
+- 🔐 **Built-in CORS and Error Handling**
+- 🔧 **Ready `.env` for configs**
 
 ---
 
-## Extending Your Project
+## 🌱 Future Plans & Call for Contributors
 
-### Adding Routes
-To add new routes, create files in the `src/routes/` directory. Example:
+We're just getting started! We plan to add:
 
-```javascript
-// src/routes/newExample.routes.js
-import express from 'express';
+- ✅ Options to choose **JavaScript or TypeScript**
+- ✅ Support for **different databases** (MySQL, PostgreSQL, etc.)
+- ✅ Customizable features during setup
 
-const router = express.Router();
-
-router.get('/', (req, res) => {
-  res.send('Hello from the new route!');
-});
-
-export default router;
-```
-
-### Middleware
-Add custom middleware in the `src/middlewares/` directory.
-
-### Database Configuration
-Edit `src/configs/db.config.js` to configure your database connection.
+👉 **We need contributors** to help add these!  
+If you're interested in helping us grow this tool, reach out or open a PR.
 
 ---
 
-## License
+## 🤝 Connect & Contribute
 
-**create-bkite** is licensed under the **MIT License**.
+- Submit issues or pull requests on [GitHub](https://github.com)
+- Connect on [LinkedIn](https://www.linkedin.com/in/sreegopalsaha/)
 
----
+Let’s build something great together.  
+**Just run `npm create bkite@latest` and start coding!**
 
-## Contributions
-
-This project is open for contributions. Feel free to:
-
-- Request a pull and open new issues.
-- Connect with me on [LinkedIn](https://www.linkedin.com/in/sreegopalsaha/) to communicate and collaborate.
-
-Start building your backend with ease using **create-bkite**! 🚀

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-bkite",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A CLI tool for scaffolding Express.js backend projects with a well-structured project setup.",
   "type": "module",
   "main": "bin/index.js",


### PR DESCRIPTION
This PR adds support for automatic port fallback during development using detect-port.

- Added a reusable `getPort` utility in the generated project's utils folder
- Updated `indexTemplate` to use `getPort`, but only in development
- Included `detect-port` as a dependency in the generated project's `packageTemplate`
- Ensures production binds strictly to the specified port

cc @sreegopalsaha 